### PR TITLE
Add localization feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ You can customize the generation with environment variables:
 - `COUNT` - how many numbers in each set (default: 6)
 - `RANGE_MAX` - maximum number in the range starting from 1 (default: 45)
 - `SEED` - seed value for reproducible results
+- `LANGUAGE` - message language (`en` or `ja`, default: `en`)
 
 Example:
 
 ```bash
 $ COUNT=7 RANGE_MAX=55 SEED=123 bin/lotto 2
+$ LANGUAGE=ja bin/lotto
 ```

--- a/bin/lotto
+++ b/bin/lotto
@@ -6,10 +6,11 @@ set_count = (ARGV[0] || 1).to_i
 count = ENV['COUNT'] ? ENV['COUNT'].to_i : LottoGenerator::DEFAULT_COUNT
 range_max = ENV['RANGE_MAX'] ? ENV['RANGE_MAX'].to_i : LottoGenerator::DEFAULT_RANGE.max
 seed = ENV['SEED'] ? ENV['SEED'].to_i : nil
+language = ENV['LANGUAGE'] || 'en'
 
 range = 1..range_max
 
-generator = LottoGenerator.new(count: count, range: range, seed: seed)
+generator = LottoGenerator.new(count: count, range: range, seed: seed, language: language)
 set_count.times do
   puts generator.generate.join(', ')
 end

--- a/lib/lotto_generator.rb
+++ b/lib/lotto_generator.rb
@@ -1,15 +1,21 @@
+require_relative 'lotto_i18n'
+
 class LottoGenerator
   DEFAULT_COUNT = 6
   DEFAULT_RANGE = (1..45)
 
-  def initialize(count: DEFAULT_COUNT, range: DEFAULT_RANGE, seed: nil)
+  def initialize(count: DEFAULT_COUNT, range: DEFAULT_RANGE, seed: nil, language: 'en')
     @count = count
     @range = range
     @rng = seed ? Random.new(seed) : Random.new
+    @language = language
   end
 
   def generate
-    raise ArgumentError, 'count is larger than range size' if @count > @range.size
+    if @count > @range.size
+      message = LottoI18n.message('count_too_large', @language)
+      raise ArgumentError, message
+    end
     @range.to_a.sample(@count, random: @rng).sort
   end
 end

--- a/lib/lotto_i18n.rb
+++ b/lib/lotto_i18n.rb
@@ -1,0 +1,14 @@
+module LottoI18n
+  MESSAGES = {
+    "count_too_large" => {
+      "en" => "count is larger than range size",
+      "ja" => "範囲のサイズより多く選択されています"
+    }
+  }
+
+  def self.message(key, lang)
+    lang ||= "en"
+    translations = MESSAGES[key] || {}
+    translations[lang] || translations["en"]
+  end
+end


### PR DESCRIPTION
## Summary
- integrate language option into CLI and generator
- supply localized error messages via `LottoI18n`
- fix Japanese translation text

## Testing
- `ruby bin/lotto 1`
- `COUNT=7 RANGE_MAX=6 ruby bin/lotto 1`
- `COUNT=7 RANGE_MAX=6 LANGUAGE=ja ruby bin/lotto 1`


------
https://chatgpt.com/codex/tasks/task_e_688370cff1ac8331a214b00c52d092e3